### PR TITLE
fix(dependency): upgrade assertj-core to 3.27.7 to fix GHSA-rqfh-9r24-8c9r

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -5,6 +5,8 @@ repositories {
 dependencies {
 
     testImplementation('com.netflix.nebula:nebula-test:11.11.3') 
+    // Fix for GHSA-rqfh-9r24-8c9r (CVE-2026-24400)
+    testImplementation('org.assertj:assertj-core:3.27.7')
     testImplementation('org.spockframework:spock-core:2.4-groovy-4.0')
     testImplementation("org.spockframework:spock-junit4:2.4-groovy-4.0")
     testImplementation("org.junit.vintage:junit-vintage-engine:6.0.2")


### PR DESCRIPTION
Upgrade `assertj-core` to 3.27.7 to fix GHSA-rqfh-9r24-8c9r

The `osvScan` task in the `security` CI job was failing due to a vulnerability found in `assertj-core:3.27.3` (CVE-2026-24400 / GHSA-rqfh-9r24-8c9r).
This vulnerability allows XXE attacks via untrusted XML input.

I have explicitly added `testImplementation 'org.assertj:assertj-core:3.27.7'` to `buildSrc/build.gradle` to force the use of the fixed version. This resolves the vulnerability scan failure.

I verified the fix locally by running:
1. `./gradlew --write-locks resolveAndLockAll`
2. `./gradlew osvInstall osvScan` (Passed)
3. `./gradlew clean build` (Passed)


---
*PR created automatically by Jules for task [5802639005805358462](https://jules.google.com/task/5802639005805358462) started by @boxheed*